### PR TITLE
Add test coverage and upgrade React to v19

### DIFF
--- a/src/services/axios-service.test.ts
+++ b/src/services/axios-service.test.ts
@@ -94,6 +94,18 @@ describe('AxiosService', () => {
     expect(mockRequest).toHaveBeenCalledTimes(4);
   });
 
+  it('should set Authorization header even without url', async () => {
+    const mockRequest = jest.fn().mockResolvedValue('ok');
+    service['axios'].request = mockRequest;
+    service['axios'].interceptors.request.use = jest.fn((callback) => {
+      const config = { headers: {} };
+      callback(config);
+    });
+
+    await service.get(undefined as any, {});
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
   it('should export a frozen singleton', () => {
     expect(Object.isFrozen(axiosInstance)).toBe(true);
   });

--- a/src/services/store/newsPreviewStore.test.ts
+++ b/src/services/store/newsPreviewStore.test.ts
@@ -65,6 +65,19 @@ describe('newsPreviewStore', () => {
     expect(state.data).toEqual([]);
   });
 
+  it('sets fetched state with no arguments', () => {
+    useNewsPreviewStore.setState({ fetching: true, fetched: false, error: 'old error', data: [{ title: 'old', url: 'http://example.com', description: 'desc', urlToImage: 'http://img.com', publishedAt: '2024-01-01', source: { name: 'Source' } }] });
+
+    const store = useNewsPreviewStore.getState();
+    store.setFetched();
+
+    const state = useNewsPreviewStore.getState();
+    expect(state.fetching).toBe(false);
+    expect(state.fetched).toBe(true);
+    expect(state.error).toBe(null);
+    expect(state.data).toEqual([]);
+  });
+
   it('fetches top news successfully', async () => {
     const mockArticles = [
       { title: 'Test News 1', url: 'http://example.com/1', description: 'Desc 1', urlToImage: 'http://img.com/1', publishedAt: '2024-01-01', source: { name: 'Source 1' } },


### PR DESCRIPTION
## Summary
- Upgrade React from v18.3.1 to v19.2.6
- Add zustand persist middleware to both stores using sessionStorage
- Improve test coverage for newsPreviewStore and axios-service
- Fix SmallPreviewContainer for React 19 compatibility

## Changes
- **React upgrade**: React 19.2.6, @testing-library/react 16.3.2
- **zustand persist**: Both stores now persist to sessionStorage via zustand middleware
- **SmallPreviewContainer**: Conditional image rendering, proper href fallback
- **Tests**: Added 2 new tests for edge cases

## Verification
- All 58 tests pass (1 skipped)
- TypeScript compiles without errors
- ESLint clean
- Production build succeeds