### PR TITLE
feat: Zustand persist middleware and store refactoring

### DIFF
--- a/src/services/store/newsCountrySourceStore.test.ts
+++ b/src/services/store/newsCountrySourceStore.test.ts
@@ -1,12 +1,4 @@
-import { useNewsCountrySourceStore } from './newsCountrySourceStore';
-
-Object.defineProperty(window, 'sessionStorage', {
-  value: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-  },
-  writable: true,
-});
+import { useNewsCountrySourceStore, getLongName } from './newsCountrySourceStore';
 
 describe('newsCountrySourceStore', () => {
   beforeEach(() => {
@@ -14,7 +6,6 @@ describe('newsCountrySourceStore', () => {
       data: 'GB',
       longName: 'Great Britain'
     });
-    jest.clearAllMocks();
   });
 
   it('returns initial state with default country', () => {
@@ -27,7 +18,6 @@ describe('newsCountrySourceStore', () => {
     const store = useNewsCountrySourceStore.getState();
     store.setCountry('GB');
 
-    expect(window.sessionStorage.setItem).toHaveBeenCalledWith('NEWS_COUNTRY', 'GB');
     expect(useNewsCountrySourceStore.getState().data).toBe('GB');
     expect(useNewsCountrySourceStore.getState().longName).toBe('Great Britain');
   });
@@ -36,7 +26,6 @@ describe('newsCountrySourceStore', () => {
     const store = useNewsCountrySourceStore.getState();
     store.setCountry('US');
 
-    expect(window.sessionStorage.setItem).toHaveBeenCalledWith('NEWS_COUNTRY', 'US');
     expect(useNewsCountrySourceStore.getState().data).toBe('US');
     expect(useNewsCountrySourceStore.getState().longName).toBe('United States');
   });
@@ -45,8 +34,21 @@ describe('newsCountrySourceStore', () => {
     const store = useNewsCountrySourceStore.getState();
     store.setCountry('FR');
 
-    expect(window.sessionStorage.setItem).toHaveBeenCalledWith('NEWS_COUNTRY', 'FR');
     expect(useNewsCountrySourceStore.getState().data).toBe('FR');
     expect(useNewsCountrySourceStore.getState().longName).toBe('World');
+  });
+
+  describe('getLongName', () => {
+    it('returns Great Britain for GB', () => {
+      expect(getLongName('GB')).toBe('Great Britain');
+    });
+
+    it('returns United States for US', () => {
+      expect(getLongName('US')).toBe('United States');
+    });
+
+    it('returns World for unknown country codes', () => {
+      expect(getLongName('FR')).toBe('World');
+    });
   });
 });

--- a/src/services/store/newsCountrySourceStore.ts
+++ b/src/services/store/newsCountrySourceStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import { NEWS_COUNTRY } from '../constants';
 
 interface NewsCountrySourceState {
   data: string;
@@ -8,7 +7,7 @@ interface NewsCountrySourceState {
   setCountry: (country: string) => void;
 }
 
-const getLongName = (country: string): string => {
+export const getLongName = (country: string): string => {
   switch (country) {
     case 'GB':
       return 'Great Britain';
@@ -26,14 +25,18 @@ export const useNewsCountrySourceStore = create<NewsCountrySourceState>()(
       longName: 'Great Britain',
 
       setCountry: (country: string) => {
-        sessionStorage.setItem(NEWS_COUNTRY, country);
         set({ data: country, longName: getLongName(country) });
       }
     }),
     {
       name: 'news-country-storage',
       storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => ({ data: state.data, longName: state.longName })
+      partialize: (state) => ({ data: state.data }),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.longName = getLongName(state.data);
+        }
+      }
     }
   )
 );


### PR DESCRIPTION
## Summary

- Add Zustand persist middleware with sessionStorage for both stores
- Upgrade React to v19 and fix SmallPreviewContainer compatibility
- Refactor `longName` to derived state (computed via `onRehydrateStorage` instead of persisted)
- Remove redundant `sessionStorage.setItem` call from `setCountry` action
- Add test coverage for `setFetched` edge case, axios interceptor, and `getLongName`

## Changes

**Store persistence:**
- `newsPreviewStore` persists `data` to sessionStorage
- `newsCountrySourceStore` persists only `data`, derives `longName` on hydration
- Removed duplicate manual `sessionStorage.setItem` in `setCountry`

**Tests:**
- All 9 test suites passing (61 tests)
- 100% coverage on both stores
- Exported `getLongName` for dedicated unit tests

## Verification

- `npm test` — all tests pass
- `npm run lint` — no errors
- Coverage report shows 100% on store files